### PR TITLE
[locale-fr] Fixed typo, added tests

### DIFF
--- a/locales/fr.js
+++ b/locales/fr.js
@@ -1,5 +1,5 @@
 var locale = [
-  ['à l'instant', 'dans un instant'],
+  ['à l\'instant', 'dans un instant'],
   ['il y a %s secondes', 'dans %s secondes'],
   ['il y a 1 minute', 'dans 1 minute'],
   ['il y a %s minutes', 'dans %s minutes'],

--- a/tests/fr-localeTest.js
+++ b/tests/fr-localeTest.js
@@ -1,0 +1,20 @@
+'use strict';
+
+var test = require('tape');
+var timeago = require('..');
+
+test('Testing locale fr', function (t) {
+
+  t.equal(timeago('2016-06-23').format('2016-06-22', 'fr'), 'il y a 1 jour');
+  t.equal(timeago('2016-06-23').format('2016-06-25', 'fr'), 'il y a 2 jours');
+
+  // test default locale
+  t.equal(timeago('2016-03-01 12:00:00', 'fr').format('2016-02-28 12:00:00'), 'il y a 2 jours');
+
+  // test setLocale
+  var newTimeAgo = timeago('2016-03-01 12:00:00');
+  newTimeAgo.setLocale('fr');
+  t.equal(newTimeAgo.format('2016-02-28 12:00:00'), 'il y a 2 jours');
+
+  t.end();
+});


### PR DESCRIPTION
#19 I had left a single quote (') in a translation string. It's now fixed.

Also I took the tests for locale zn_CH from test.js and put them in a new file called fr-localeTest.js. I didn't reinclude all the tests for locale en as they are already in test.js. Feel free to do something different if you feel like it's better!

PS: Sorry for breaking your code with my original translation ^^

Also, please note I did not run the tests as I do not have an environment for JS dev.
