### PR TITLE
Updating "just now" label for pt_BR locale

### DIFF
--- a/locales/pt_BR.js
+++ b/locales/pt_BR.js
@@ -1,6 +1,6 @@
 module.exports = function(number, index) {
   return [
-    ['há pouco', 'daqui um pouco'],
+    ['agora mesmo', 'daqui um pouco'],
     ['há %s segundos', 'em %s segundos'],
     ['há um minuto', 'em um minuto'],
     ['há %s minutos', 'em %s minutos'],


### PR DESCRIPTION
#19 Updating portuguese version of `"just now"` label to something more close to the english version.

**Current translation:**
`"há pouco"` => `"some time ago"` (it gives a notion of little time ago, but now of "just now")

**After this PR:**
`"agora mesmo"` => `"just now"`
