### PR TITLE
Test builder class for easier testing

### DIFF
--- a/tests/locales/ru.js
+++ b/tests/locales/ru.js
@@ -1,68 +1,65 @@
-var timeago = require('../../');
+var tb = require('../test-builder')(Date.now()).register('ru', require('../../locales/ru'), true);
 
 module.exports = function(t) {
-  var tm = timeago('2016-06-20 12:30:00', 'ru');
-  tm.register('ru', require('../../locales/ru'));
+  // test seconds
+  t.equal(tb.subSeconds(1), 'только что');
+  t.equal(tb.subSeconds(10), '10 секунд назад');
+  t.equal(tb.subSeconds(21), '21 секунду назад');
+  t.equal(tb.subSeconds(22), '22 секунды назад');
+  t.equal(tb.addSeconds(1), 'через несколько секунд');
+  t.equal(tb.addSeconds(10), 'через 10 секунд');
+  t.equal(tb.addSeconds(21), 'через 21 секунду');
+  t.equal(tb.addSeconds(22), 'через 22 секунды');
 
-  // test second
-  t.equal(tm.format('2016-06-20 12:30:00'), 'только что');
-  t.equal(tm.format('2016-06-20 12:29:50'), '10 секунд назад');
-  t.equal(tm.format('2016-06-20 12:29:39'), '21 секунду назад');
-  t.equal(tm.format('2016-06-20 12:29:38'), '22 секунды назад');
-  t.equal(tm.format('2016-06-20 12:30:01'), 'через несколько секунд');
-  t.equal(tm.format('2016-06-20 12:30:10'), 'через 10 секунд');
-  t.equal(tm.format('2016-06-20 12:30:21'), 'через 21 секунду');
-  t.equal(tm.format('2016-06-20 12:30:22'), 'через 22 секунды');
+  // test minutes
+  t.equal(tb.subMinutes(1), 'минуту назад');
+  t.equal(tb.subMinutes(2), '2 минуты назад');
+  t.equal(tb.subMinutes(5), '5 минут назад');
+  t.equal(tb.subMinutes(21), '21 минуту назад');
+  t.equal(tb.addMinutes(1), 'через минуту');
+  t.equal(tb.addMinutes(2), 'через 2 минуты');
+  t.equal(tb.addMinutes(5), 'через 5 минут');
+  t.equal(tb.addMinutes(21), 'через 21 минуту');
 
-  // test minute
-  t.equal(tm.format('2016-06-20 12:29:00'), 'минуту назад');
-  t.equal(tm.format('2016-06-20 12:28:00'), '2 минуты назад');
-  t.equal(tm.format('2016-06-20 12:25:00'), '5 минут назад');
-  t.equal(tm.format('2016-06-20 12:9:00'), '21 минуту назад');
-  t.equal(tm.format('2016-06-20 12:31:00'), 'через минуту');
-  t.equal(tm.format('2016-06-20 12:32:00'), 'через 2 минуты');
-  t.equal(tm.format('2016-06-20 12:35:00'), 'через 5 минут');
-  t.equal(tm.format('2016-06-20 12:51:00'), 'через 21 минуту');
+  // test hours
+  t.equal(tb.subHours(1), 'час назад');
+  t.equal(tb.subHours(2), '2 часа назад');
+  t.equal(tb.subHours(5), '5 часов назад');
+  t.equal(tb.subHours(21), '21 час назад');
+  t.equal(tb.addHours(1), 'через час');
+  t.equal(tb.addHours(2), 'через 2 часа');
+  t.equal(tb.addHours(5), 'через 5 часов');
+  t.equal(tb.addHours(21), 'через 21 час');
 
-  // test hour
-  t.equal(tm.format('2016-06-20 11:30:00'), 'час назад');
-  t.equal(tm.format('2016-06-20 10:30:00'), '2 часа назад');
-  t.equal(tm.format('2016-06-20 7:30:00'), '5 часов назад');
-  t.equal(tm.format('2016-06-19 15:30:00'), '21 час назад');
-  t.equal(tm.format('2016-06-20 13:30:00'), 'через час');
-  t.equal(tm.format('2016-06-20 14:30:00'), 'через 2 часа');
-  t.equal(tm.format('2016-06-20 17:30:00'), 'через 5 часов');
-  t.equal(tm.format('2016-06-21 9:30:00'), 'через 21 час');
+  // test days
+  t.equal(tb.subDays(1), 'вчера');
+  t.equal(tb.subDays(2), '2 дня назад');
+  t.equal(tb.subDays(5), '5 дней назад');
+  t.equal(tb.addDays(1), 'завтра');
+  t.equal(tb.addDays(2), 'через 2 дня');
+  t.equal(tb.addDays(5), 'через 5 дней');
 
-  // test day
-  t.equal(tm.format('2016-06-19 12:30:00'), 'вчера');
-  t.equal(tm.format('2016-06-18 12:30:00'), '2 дня назад');
-  t.equal(tm.format('2016-06-15 12:30:00'), '5 дней назад');
-  t.equal(tm.format('2016-06-21 12:30:00'), 'завтра');
-  t.equal(tm.format('2016-06-22 12:30:00'), 'через 2 дня');
-  t.equal(tm.format('2016-06-25 12:30:00'), 'через 5 дней');
+  // test weeks
+  t.equal(tb.subWeeks(1), 'неделю назад');
+  t.equal(tb.subWeeks(2), '2 недели назад');
+  t.equal(tb.addWeeks(1), 'через неделю');
+  t.equal(tb.addWeeks(2), 'через 2 недели');
 
-  // test week
-  t.equal(tm.format('2016-06-13 12:30:00'), 'неделю назад');
-  t.equal(tm.format('2016-06-06 12:30:00'), '2 недели назад');
-  t.equal(tm.format('2016-06-27 12:30:00'), 'через неделю');
-  t.equal(tm.format('2016-07-04 12:30:00'), 'через 2 недели');
+  // test months
+  t.equal(tb.subMonths(1), 'месяц назад');
+  t.equal(tb.subMonths(2), '2 месяца назад');
+  t.equal(tb.subMonths(5), '5 месяцев назад');
+  t.equal(tb.addMonths(1), 'через месяц');
+  t.equal(tb.addMonths(2), 'через 2 месяца');
+  t.equal(tb.addMonths(5), 'через 5 месяцев');
 
-  // test month
-  t.equal(tm.format('2016-05-20 12:30:00'), 'месяц назад');
-  t.equal(tm.format('2016-04-20 12:30:00'), '2 месяца назад');
-  t.equal(tm.format('2016-01-19 12:30:00'), '5 месяцев назад');
-  t.equal(tm.format('2016-07-21 12:30:00'), 'через месяц');
-  t.equal(tm.format('2016-08-20 12:30:00'), 'через 2 месяца');
-  t.equal(tm.format('2016-11-20 12:30:00'), 'через 5 месяцев');
-
-  // test year
-  t.equal(tm.format('2015-06-20 12:30:00'), 'год назад');
-  t.equal(tm.format('2014-06-20 12:30:00'), '2 года назад');
-  t.equal(tm.format('2011-06-20 12:30:00'), '5 лет назад');
-  t.equal(tm.format('1995-06-20 12:30:00'), '21 год назад');
-  t.equal(tm.format('2017-06-20 12:30:00'), 'через год');
-  t.equal(tm.format('2018-06-20 12:30:00'), 'через 2 года');
-  t.equal(tm.format('2021-06-20 12:30:00'), 'через 5 лет');
-  t.equal(tm.format('2037-06-20 12:30:00'), 'через 21 год');
+  // test years
+  t.equal(tb.subYears(1), 'год назад');
+  t.equal(tb.subYears(2), '2 года назад');
+  t.equal(tb.subYears(5), '5 лет назад');
+  t.equal(tb.sub({years: 19, months: 24}), '21 год назад'); // 21 years ago
+  t.equal(tb.addYears(1), 'через год');
+  t.equal(tb.addYears(2), 'через 2 года');
+  t.equal(tb.addYears(5), 'через 5 лет');
+  t.equal(tb.add({years: 20, months: 12}), 'через 21 год'); // in 21 years
 };

--- a/tests/test-builder.js
+++ b/tests/test-builder.js
@@ -1,0 +1,247 @@
+'use strict';
+
+const timeago = require('../'),
+  HOURS_IN_MONTH = 24*7*(365/7/12),
+  DAYS_IN_WEEK = 7;
+
+class TimeagoBuilder {
+  constructor(nowDate, defaultLocale) {
+    defaultLocale = defaultLocale || 'en';
+
+    /** @private */
+    this.nowDate = new Date(nowDate);
+
+    /** @private */
+    this.timeago = timeago(nowDate);
+
+    this.useLocale(defaultLocale);
+  }
+
+  /**
+   * Falls back to `timeago().register` method. Third parameter tells to instantly use registered locale
+   * @param code
+   * @param fn
+   * @param {boolean} use
+   * @returns {TimeagoBuilder}
+   */
+  register(code, fn, use) {
+    use = use || false;
+    this.timeago.register(code, fn);
+
+    if (use) {
+      this.timeago.setLocale(code);
+    }
+
+    return this;
+  }
+
+  /**
+   * Falls back to `timeago().setLocale` method
+   * @param code
+   * @returns {TimeagoBuilder}
+   */
+  useLocale(code) {
+    this.timeago.setLocale(code);
+
+    return this;
+  }
+
+  /**
+   * Falls back `timeago.format()` value
+   * @param [format]
+   * @returns {string}
+   */
+  getFormat(format) {
+    return this.timeago.format(format || this.nowDate.getTime());
+  }
+
+  /**
+   * Adds piece of time in OO way
+   * @param {{seconds?: number, minutes?: number, hours?: number, days?: number, weeks?: number, months?: number, years?: number}} obj
+   * @returns {string}
+   */
+  add(obj) {
+    return this.setAndFormat(date => {
+      if (obj.seconds > 0) this.setSeconds(date, obj.seconds);
+      if (obj.minutes > 0) this.setMinutes(date, obj.minutes);
+      if (obj.hours > 0) this.setHours(date, obj.hours);
+      if (obj.days > 0) this.setDays(date, obj.days);
+      if (obj.weeks > 0) this.setWeeks(date, obj.weeks);
+      if (obj.months > 0) this.setMonths(date, obj.months);
+      if (obj.years > 0) this.setYears(date, obj.years);
+    });
+  }
+
+  /**
+   * Subs piece of time in OO way
+   * @param {{seconds?: number, minutes?: number, hours?: number, days?: number, weeks?: number, months?: number, years?: number}} obj
+   * @returns {string}
+   */
+  sub(obj) {
+    return this.setAndFormat(date => {
+      if (obj.seconds > 0) this.setSeconds(date, -obj.seconds);
+      if (obj.minutes > 0) this.setMinutes(date, -obj.minutes);
+      if (obj.hours > 0) this.setHours(date, -obj.hours);
+      if (obj.days > 0) this.setDays(date, -obj.days);
+      if (obj.weeks > 0) this.setWeeks(date, -obj.weeks);
+      if (obj.months > 0) this.setMonths(date, -obj.months);
+      if (obj.years > 0) this.setYears(date, -obj.years);
+    });
+  }
+
+  /**
+   *
+   * @param setFn
+   * @private
+   * @throws TypeError
+   */
+  setAndFormat(setFn) {
+    if (typeof setFn !== 'function') throw new TypeError('`setFn` must be callable');
+
+    const date = new Date(this.nowDate.getTime()),
+      result = setFn(date);
+
+    let val;
+
+    if (result instanceof Date) {
+      val = result.getTime();
+    } else if (result === parseFloat(result)) {
+      val = result;
+    } else {
+      val = date;
+    }
+
+    return this.getFormat(val);
+  }
+
+}
+/**
+ * Dynamically generates add/sub/set methods
+ */
+['Seconds', 'Minutes', 'Hours', 'Date', 'Weeks', 'Months', 'FullYear'].forEach(fnName => {
+  if (fnName === 'Weeks') {
+    /** @private */
+    TimeagoBuilder.prototype.setWeeks = function(date, n) {
+      return date.setDate(date.getDate() + n * DAYS_IN_WEEK);
+    };
+  } else if (fnName === 'Months') {
+    /** @private */
+    TimeagoBuilder.prototype.setMonths = function(date, n) {
+      return date.setHours(date.getHours() + n * HOURS_IN_MONTH);
+    };
+  } else {
+    // setSeconds, setMinutes, setHours, setDate, setFullYear
+    TimeagoBuilder.prototype[`set${fnName}`] = function(date, n) {
+      return date[`set${fnName}`](date[`get${fnName}`]() + n);
+    };
+  }
+
+  // addSeconds, addMinutes, addHours, addDate, addWeeks, addMonths, addFullYear
+  TimeagoBuilder.prototype[`add${fnName}`] = function(n) {
+    return this.setAndFormat(date => this[`set${fnName}`](date, n));
+  };
+
+  // subSeconds, subMinutes, subHours, subDate, subWeeks, subMonths, subFullYear
+  TimeagoBuilder.prototype[`sub${fnName}`] = function(n) {
+    return this.setAndFormat(date => this[`set${fnName}`](date, -n));
+  };
+});
+
+// set aliases for more suitable names
+TimeagoBuilder.prototype.addDays = TimeagoBuilder.prototype.addDate;
+TimeagoBuilder.prototype.subDays = TimeagoBuilder.prototype.subDate;
+/** @private */
+TimeagoBuilder.prototype.setDays = TimeagoBuilder.prototype.setDate;
+TimeagoBuilder.prototype.addYears = TimeagoBuilder.prototype.addFullYear;
+TimeagoBuilder.prototype.subYears = TimeagoBuilder.prototype.subFullYear;
+/** @private */
+TimeagoBuilder.prototype.setYears = TimeagoBuilder.prototype.setFullYear;
+
+// exports factory function
+exports = module.exports = (nowDate, locale) => new TimeagoBuilder(nowDate, locale);
+
+// below are for dynamically generated methods
+
+/**
+ * @name TimeagoBuilder#addSeconds
+ * @function
+ * @param n
+ */
+
+/**
+ * @name TimeagoBuilder#subSeconds
+ * @function
+ * @param n
+ */
+
+/**
+ * @name TimeagoBuilder#setSeconds
+ * @function
+ * @private
+ * @param date
+ * @param n
+ */
+
+/**
+ * @name TimeagoBuilder#addMinutes
+ * @function
+ * @param n
+ */
+
+/**
+ * @name TimeagoBuilder#subMinutes
+ * @function
+ * @param n
+ */
+
+/**
+ * @name TimeagoBuilder#setMinutes
+ * @function
+ * @private
+ * @param date
+ * @param n
+ */
+
+/**
+ * @name TimeagoBuilder#addHours
+ * @function
+ * @param n
+ */
+
+/**
+ * @name TimeagoBuilder#subHours
+ * @function
+ * @param n
+ */
+
+/**
+ * @name TimeagoBuilder#setHours
+ * @function
+ * @private
+ * @param date
+ * @param n
+ */
+
+/**
+ * @name TimeagoBuilder#addWeeks
+ * @function
+ * @param n
+ */
+
+/**
+ * @name TimeagoBuilder#subWeeks
+ * @function
+ * @param n
+ */
+
+/**
+ * @name TimeagoBuilder#addMonths
+ * @function
+ * @param n
+ */
+
+/**
+ * @name TimeagoBuilder#subMonths
+ * @function
+ * @param n
+ */


### PR DESCRIPTION
Since we start cover locales with tests it would be great to have easier tool to test the time, because sometimes it's sad to calculate, e.g. what is the result of `adding 15 days to 18 of December, 2016`. Moreover it would be great to have ability to "read" test written for other languages.

This PR introduces a class for easier testing. It wraps the `timeago` and provides human-friendly methods for manipulations with internal `timeago().format` method. Thanks to these interface it becomes intuitively clear about which piece of time you test regardless of the language.
## How to use

`tests/test-builder.js` exports [factory method](https://github.com/hustcc/timeago.js/compare/master...likerRr:test-builder?expand=1#diff-5fcce67ebb1f316f99852bb1731f452eR161) that accepts the same arguments as the `timeago` function and returns an instance of the builder with familiar API. 

``` javascript
const tb = require('../test-builder')(Date.now(), 'en');
// you don't need to worry about initial date value, in fact it doesn't matter at all
```
### Instance API

**register(code, fn, use)**

> Falls back to `timeago().register` method. 3rd argument tells to use registered locale.

**useLocale(code)**

> Same as `timeago().setLocale`

**getFormat(format)**

> Same as `timeago().format`

**addSeconds(n)**
**addMinutes(n)**
**addHours(n)**
**addDays(n)**
**addWeeks(n)**
**addMonths(n)**
**addYears(n)**

> According to the name of method adds `n` amount of time to initial time and returns timeago statement. E.g:

``` javascript
var tb = require('../test-builder')(Date.now(), 'en');
console.log(tb.addSeconds(1) === 'a while'); // true
```

**subSeconds(n)**
**subMinutes(n)**
**subHours(n)**
**subDays(n)**
**subWeeks(n)**
**subMonths(n)**
**subYears(n)**

> Same as `add${Time}` but subs provided amount of time. E.g.:

``` javascript
var tb = require('../test-builder')(Date.now(), 'en');
console.log(tb.subSeconds(1) === 'just now'); // true
```

**add(obj)**
**sub(obj)**
_obj: {seconds?: number, minutes?: number, hours?: number, days?: number, weeks?: number, months?: number, years?: number}_

> Methods allow to combine several time statements, e.g.:

``` javascript
var tb = require('../test-builder')(Date.now(), 'en');
console.log(tb.add({years: 1, months: 12}) === 'in 2 years'); // true
console.log(tb.sub({years: 1, months: 12}) === '2 years ago'); // true
```

> ### IMPORTANT
> 
> `add/sub` methods don't actually add or sub amount of time to initial date, instead they just make call to internal `timeago().format` method providing corresponding argument to it.

Take a look onto attached test file for the `ru` locale, hope you like it.

@hustcc why did you change your profile photo? It was cute 😜
