### PR TITLE
Add .DS_Store and .idea to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .project
 .settings
+.idea/*
+.DS_Store
 
 node_modules/*
 


### PR DESCRIPTION
Hi!
I added **.DS_Store** and **.idea/** to .gitignore.
Because yesterday I added ja local file, these files were tracked by git.
- .DS_Store: is generated by Mac system [Wikipedia](https://en.wikipedia.org/wiki/.DS_Store)
- .idea: is generated by PyCharm
