### PR TITLE
ES6 tests

### DIFF
--- a/tests/locales_test.js
+++ b/tests/locales_test.js
@@ -1,50 +1,52 @@
 'use strict';
 
-var fs = require('fs');
-var test = require('tape');
-var timeago = require('..');
-var pys = require('pys');
+const fs = require('fs');
+const test = require('tape');
+const timeago = require('..');
+const pys = require('pys');
 
 // all the locales code, if missing, please add them.
-var all_locales = require('../locales/locales.js'); 
+const allLocales = require('../locales/locales.js');
 
-function test_locales(tobeTested) {
-  test('Testing locales', function (t) {
-    for (var i = 0; i < tobeTested.length ; i++) {
-      var locale_name = pys(tobeTested[i])('0:-3');
-      t.ok(all_locales.indexOf(locale_name) >= 0, 'locale [' + locale_name + ']');
+function testLocales(tobeTested) {
+  test('Testing locales', t => {
+    tobeTested.forEach(file => {
+      const localeName = pys(file)('0:-3');
+      t.ok(allLocales.indexOf(localeName) >= 0, 'locale [' + localeName + ']');
 
-      console.log('\nTesting locales [' + locale_name + ']');
+      console.log('\nTesting locales [' + localeName + ']');
 
-      var locale = require('../locales/' + locale_name);
+      const localeFn = require('../locales/' + localeName);
       // test locales
-      var newTimeAgo = timeago(null, '2016-06-23');
-      timeago.register(locale_name, locale);
-      t.equal(newTimeAgo.format('2016-06-22', locale_name), locale(1, 6)[0]);
-      t.equal(newTimeAgo.format('2016-06-25', locale_name), locale(2, 7)[1].replace('%s', '2'));
+      let newTimeAgo = timeago(null, '2016-06-23');
+      newTimeAgo.register(localeName, localeFn);
+      t.equal(newTimeAgo.format('2016-06-22', localeName), localeFn(1, 6)[0]);
+      t.equal(newTimeAgo.format('2016-06-25', localeName), localeFn(2, 7)[1].replace('%s', '2'));
 
       // test default locale
-      var newTimeAgo = timeago(locale_name, '2016-03-01 12:00:00');
-      timeago.register(locale_name, locale);
-      t.equal(newTimeAgo.format('2016-02-28 12:00:00'), locale(2, 7)[0].replace('%s', '2'));
+      newTimeAgo = timeago(localeName, '2016-03-01 12:00:00');
+      newTimeAgo.register(localeName, localeFn);
+      t.equal(newTimeAgo.format('2016-02-28 12:00:00'), localeFn(2, 7)[0].replace('%s', '2'));
 
       // test setLocale
-      var newTimeAgo = timeago(null, '2016-03-01 12:00:00');
-      timeago.register(locale_name, locale);
-      newTimeAgo.setLocale(locale_name);
-      t.equal(newTimeAgo.format('2016-02-28 12:00:00'), locale(2, 7)[0].replace('%s', '2'));
-    }
+      newTimeAgo = timeago(null, '2016-03-01 12:00:00');
+      newTimeAgo.register(localeName, localeFn);
+      newTimeAgo.setLocale(localeName);
+      t.equal(newTimeAgo.format('2016-02-28 12:00:00'), localeFn(2, 7)[0].replace('%s', '2'));
+    });
+
     t.end();
   });
 }
 
 // read all the locales in `locales` dir
-fs.readdir('locales', function(err, files) {
+fs.readdir('locales', (err, files) => {
   // rm locales.js file
-  var index = files.indexOf('locales.js');
+  const index = files.indexOf('locales.js');
+
   if (index > -1) {
     files.splice(index, 1);
   }
   // test them
-  test_locales(files);
+  testLocales(files);
 });

--- a/tests/locales_test.js
+++ b/tests/locales_test.js
@@ -19,18 +19,18 @@ function testLocales(tobeTested) {
       const localeFn = require('../locales/' + localeName);
       // test locales
       let newTimeAgo = timeago(null, '2016-06-23');
-      newTimeAgo.register(localeName, localeFn);
+      timeago.register(localeName, localeFn);
       t.equal(newTimeAgo.format('2016-06-22', localeName), localeFn(1, 6)[0]);
       t.equal(newTimeAgo.format('2016-06-25', localeName), localeFn(2, 7)[1].replace('%s', '2'));
 
       // test default locale
       newTimeAgo = timeago(localeName, '2016-03-01 12:00:00');
-      newTimeAgo.register(localeName, localeFn);
+      timeago.register(localeName, localeFn);
       t.equal(newTimeAgo.format('2016-02-28 12:00:00'), localeFn(2, 7)[0].replace('%s', '2'));
 
       // test setLocale
       newTimeAgo = timeago(null, '2016-03-01 12:00:00');
-      newTimeAgo.register(localeName, localeFn);
+      timeago.register(localeName, localeFn);
       newTimeAgo.setLocale(localeName);
       t.equal(newTimeAgo.format('2016-02-28 12:00:00'), localeFn(2, 7)[0].replace('%s', '2'));
     });

--- a/tests/test.js
+++ b/tests/test.js
@@ -1,23 +1,22 @@
 'use strict';
 
-var test = require('tape');
-var timeago = require('..');
+const test = require('tape');
+const timeago = require('..');
+const fs = require('fs');
+const pys = require('pys');
+const testBuilder = require('./test-builder');
 
-var fs = require('fs');
-var pys = require('pys');
-
-test('timeago.js show be tested', function (t) {
+test('timeago.js show be tested', t => {
   // locale tests #################################################################
   // read all the locales test in `tests/locales` dir
-  fs.readdir('tests/locales', function(err, files) {
-    var locale = '';
-    for (var i = 0; i < files.length ; i++) {
-      locale = pys(files[i])('0:-3');
+  fs.readdir('tests/locales', (err, files) => {
+    files.forEach(file => {
+      const locale = pys(file)('0:-3');
       console.log('\nLocale testcase for ['+ locale +']');
       // require in the locales testcases
-      var tb = require('./test-builder')(Date.now()).register(locale, require('../locales/' + locale), true);
+      const tb = testBuilder(Date.now()).register(locale, require('../locales/' + locale), true);
       require('./locales/' + locale)(t, tb);
-    }
+    })
   });
   // end locale tests #############################################################
 
@@ -28,9 +27,8 @@ test('timeago.js show be tested', function (t) {
   t.equal(timeago(null, '2016-06-23').format('2016-06-25', 'zh_CN'), '2天后');
 
   // test register locale
-  var timeago_reg = new timeago(null, '2016-06-23');
-  timeago.register('test_local', function(number, index) {
-    return [
+  const timeagoReg = timeago('2016-06-23');
+  timeagoReg.register('test_local', (number, index) => [
       ["just xxx", "a while"],
       ["%s seconds xxx", "in %s seconds"],
       ["1 minute xxx", "in 1 minute"],
@@ -45,19 +43,21 @@ test('timeago.js show be tested', function (t) {
       ["%s months xxx", "in %s months"],
       ["1 year xxx", "in 1 year"],
       ["%s years xxx", "in %s years"]
-    ][index];
-  });
-  t.equal(timeago_reg.format('2016-06-22', 'test_local'), '1 day xxx');
+    ][index]
+  );
+  t.equal(timeagoReg.format('2016-06-22', 'test_local'), '1 day xxx');
+
   // testcase for other points
   // relative now
-  t.equal(timeago().format(new Date().getTime() - 11 * 1000 * 60 * 60), '11 hours ago');
+  t.equal(timeago().format(Date.now() - 11 * 1000 * 60 * 60), '11 hours ago');
 
   // timestamp is also can work
-  var current = new Date().getTime();
+  let current = Date.now();
   t.equal(timeago(null, current).format(current - 8 * 1000 * 60 * 60 * 24), '1 week ago');
   t.equal(timeago(null, current).format(current - 31536000 * 1000 + 1000), '11 months ago');
+
   // Date()
-  var current = new Date();
+  current = new Date();
   t.equal(timeago(null, current).format(current), 'just now');
 
 
@@ -70,7 +70,7 @@ test('timeago.js show be tested', function (t) {
   t.equal(timeago('zh_CN', '2016-03-01 12:00:00').format('2016-02-28 12:00:00'), '2天前');
 
   // test setLocale
-  var newTimeAgo = timeago(null, '2016-03-01 12:00:00');
+  const newTimeAgo = timeago(null, '2016-03-01 12:00:00');
   t.equal(newTimeAgo.format('2016-02-28 12:00:00'), '2 days ago');
   newTimeAgo.setLocale('zh_CN');
   t.equal(newTimeAgo.format('2016-02-28 12:00:00'), '2天前');

--- a/tests/test.js
+++ b/tests/test.js
@@ -6,7 +6,7 @@ const fs = require('fs');
 const pys = require('pys');
 const testBuilder = require('./test-builder');
 
-test('timeago.js show be tested', t => {
+test('timeago.js should be tested', t => {
   // locale tests #################################################################
   // read all the locales test in `tests/locales` dir
   fs.readdir('tests/locales', (err, files) => {
@@ -27,8 +27,8 @@ test('timeago.js show be tested', t => {
   t.equal(timeago(null, '2016-06-23').format('2016-06-25', 'zh_CN'), '2天后');
 
   // test register locale
-  const timeagoReg = timeago('2016-06-23');
-  timeagoReg.register('test_local', (number, index) => [
+  const timeagoReg = timeago(null, '2016-06-23');
+  timeago.register('test_local', (number, index) => [
       ["just xxx", "a while"],
       ["%s seconds xxx", "in %s seconds"],
       ["1 minute xxx", "in 1 minute"],

--- a/tests/test_dev.js
+++ b/tests/test_dev.js
@@ -1,9 +1,9 @@
 'use strict';
 
-var test = require('tape');
-var timeago = require('..');
+const test = require('tape');
+const timeago = require('..');
 
-test('timeago.js next interval show be tested', function (t) {
+test('timeago.js next interval show be tested', t => {
   t.true(timeago().next_interval(0.134), 1);
   t.true(timeago().next_interval(8), 1);
   t.true(timeago().next_interval(59), 1);


### PR DESCRIPTION
Since tests are run by node, this PR adds ES6 syntax for test files. Nodejs v5+ required. 

Also [there is a note](https://nodejs.org/en/blog/community/v5-to-v7/) in their blog where it's said that in December 2016 v5 will no longer be maintained and receive critical fixes. So it's time to update the code ☝
