### PR TITLE
Add datetime attribute alternative following W3C recommendations

### DIFF
--- a/src/timeago.js
+++ b/src/timeago.js
@@ -96,6 +96,7 @@ function () {
   }
   // get the datetime attribute, jQuery and DOM
   function getDateAttr(node) {
+    if(node.dataset.timeago) return node.dataset.timeago;
     if (node.getAttribute) return node.getAttribute(ATTR_DATETIME);
     if(node.attr) return node.attr(ATTR_DATETIME);
   }


### PR DESCRIPTION
Picky, I know.
In your [README.md](https://github.com/hustcc/timeago.js/blob/master/README.md) you mentioned the possible use of a `data-timeago` attribute instead of the "W3C-illegal" datetime attribute (see  [W3C Recommendation](https://www.w3.org/TR/html5/dom.html#embedding-custom-non-visible-data-with-the-data-*-attributes)) which we couldn't actually use before this PR.
This PR adds the possibility to use the `data-timeago` attribute for the automatic rendering while maintaining backwards compatibility.