### PR TITLE
Delete `if (node.attr)` in `getDateAttr(node)`

### DIFF
--- a/dist/timeago.js
+++ b/dist/timeago.js
@@ -96,9 +96,8 @@ function () {
   }
   // get the datetime attribute, jQuery and DOM
   function getDateAttr(node) {
-    if(node.dataset.timeago) return node.dataset.timeago;
+    if (node.dataset.timeago) return node.dataset.timeago;
     if (node.getAttribute) return node.getAttribute(ATTR_DATETIME);
-    if(node.attr) return node.attr(ATTR_DATETIME);
   }
   /**
    * timeago: the function to get `timeago` instance.


### PR DESCRIPTION
```
this.render = function(nodes, locale) {
  if (nodes.length === undefined) nodes = [nodes];
  for (var i = 0; i < nodes.length; i++) {
    doRender(nodes[i], getDateAttr(nodes[i]), locale, ++ cnt); // render item
  }
};
```

When you loop the jQuery objects in `for...`, the `nodes[i]` will be the DOM element to the jQuery object

so `if (node.attr) return node.attr(ATTR_DATETIME);` will never be executed even you pass jQuery objects.

Best wishes.