### PR TITLE
Fix memory leak

### DIFF
--- a/src/timeago.js
+++ b/src/timeago.js
@@ -156,11 +156,11 @@ function () {
       self = this,
       tid;
     // delete previously assigned timeout's id to node
-    //delete timers[getTimeoutId(node)]; // if delete it from object, then `cancel()` may can not cancel all the timer.
     node.innerHTML = formatDiff(diff, locale, this.defaultLocale);
     // waiting %s seconds, do the next render
     timers[tid = setTimeout(function() {
       self.doRender(node, date, locale);
+      delete timers[tid];
     }, Math.min(nextInterval(diff) * 1000, 0x7FFFFFFF))] = 0; // there is no need to save node in object.
     // set attribute date-tid
     setTidAttr(node, tid);


### PR DESCRIPTION
We must clean timers object from "dead" timers, otherwise the timers object will grow until it consumes all the memory. Look at the screenshot:
![before_fix](http://clip2net.com/clip/m182888/77372-clip-76kb.png?nocache=1) 
It's taken after 22 seconds on timeago's demo page. There are only 2 live render nodes, but there are already 27 timers.

Situation after the fix:
![after_fix](http://clip2net.com/clip/m182888/edf41-clip-21kb.png?nocache=1)

Previous timer id will be deleted only when a new timer id is assigned to the node. This should not prevent node from canceling it's timer.