### PR TITLE
Add minimal interval to refresh (timeago.render)

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ format('2016-06-12', 'en_US');
 There only 4 API:
 
  - **format(date[, locale = 'en_US', relativeDate = new Date()])**: format a Date instance / timestamp / date string to string.
- - **render(dom[, locale = 'en_US', relativeDate = new Date()])**: make a dom automatic rendering.
+ - **render(dom[, locale = 'en_US', relativeDate = new Date(), minInt = 1])**: make a dom automatic rendering.
  - **cancel([dom])**: cancel automatic rendering.
  - **register(locale, localeFunc)**: register a new locale, build-in locale contains: `en_US`, `zh_CN`.
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -76,7 +76,7 @@ format('2016-06-12', 'en_US');
 总共只有 4 个 API：
 
  - **format(date[, locale = 'en_US', relativeDate = new Date()])**: 格式化日期实例 / 时间戳 / 时间格式字符串。
- - **render(dom[, locale = 'en_US', relativeDate = new Date()])**: 实时渲染格式化一个 dom 元素。
+ - **render(dom[, locale = 'en_US', relativeDate = new Date(), minInt = 1])**: 实时渲染格式化一个 dom 元素。
  - **cancel([dom])**: 取消实时渲染。
  - **register(locale, localeFunc)**: 注册一个新的本地语言，目前内置语言包括：`en_US`, `zh_CN`。
 

--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -3,6 +3,7 @@
  * Contract: i@hust.cc
  */
 
+import { advanceBy, advanceTo, clear } from 'jest-date-mock';
 import pkg from '../package.json';
 import { format, render, cancel, register, version } from '../src/';
 
@@ -20,6 +21,7 @@ describe('index', () => {
 
   test('format', () => {
     expect(format(new Date() - 7000)).toBe('just now');
+    expect(format(new Date() - 11000)).toBe('11 seconds ago');
 
     expect(format(new Date() - 1000 * 1000, 'zh_CN')).toBe('16 分钟前');
   });
@@ -33,6 +35,43 @@ describe('index', () => {
     render({});
     jest.advanceTimersByTime(30000);
     expect(format(new Date() - 1000 * 1000, 'zh_CN')).toBe('16 分钟前');
+  });
+
+  test('render with minimal interval', () => {
+    const minIntTest = (dt, minInt, duration, before, after) => {
+      // Mock Date
+      advanceTo(new Date());
+
+      // Prepare the element
+      let n = document.createElement('time');
+      n.setAttribute('datetime', dt.toISOString());
+
+      render(n, undefined, undefined, minInt);
+
+      // Test the initial state
+      expect(n.innerHTML).toBe(before);
+
+      // Advance time
+      for (var i = 0; i < duration; i++) {
+        advanceBy(1000);
+        jest.advanceTimersByTime(1000);
+      }
+      // Test the initial state
+      expect(n.innerHTML).toBe(after);
+
+      // Clean up Date mocking
+      clear();
+    };
+    minIntTest(new Date(),  1, 14, 'just now', '14 seconds ago');
+    minIntTest(new Date(),  5, 14, 'just now', '10 seconds ago');
+    minIntTest(new Date(),  5, 15, 'just now', '15 seconds ago');
+    minIntTest(new Date(), undefined, 14, 'just now', '14 seconds ago');
+    minIntTest(new Date(), -1, 14, 'just now', '14 seconds ago');
+    minIntTest(new Date(), 60, 59, 'just now', 'just now');
+    const d = new Date();
+    d.setSeconds(d.getSeconds() - 11);
+    minIntTest(d, 1, 14, '11 seconds ago', '25 seconds ago');
+    minIntTest(d, 5, 14, '11 seconds ago', '21 seconds ago');
   });
 
   test('cancel', () => {

--- a/gh-pages/demo.html
+++ b/gh-pages/demo.html
@@ -62,6 +62,13 @@
 		<input type="button" onclick="javascript:start_vi();" value="Start." />
 		<input type="button" onclick="javascript:stop_vi();" value="Stop." />
 	</p>
+
+	<h3>Test refreshing with minimal interval (every 5 second update) ?</h3>
+	<p class="minint example">
+		You opened this page <time class="strong single minint">when you opened the page</time>.
+		<input type="button" onclick="javascript:start_minint();" value="Start." />
+		<input type="button" onclick="javascript:stop_minint();" value="Stop." />
+	</p>
 </div>
 <div id="footer">
 	Copyright &copy; 2016 How to user it, see <a href="https://timeago.org/" target="_blank" rel="nofollow">timeago.js</a>.
@@ -109,6 +116,14 @@
 
   function stop_vi() {
     timeago.cancel($('.vi.single'));
+  }
+
+  function start_minint() {
+    timeago.render(document.querySelector('.minint.single'), undefined, undefined, 5);
+  }
+
+  function stop_minint() {
+    timeago.cancel(document.querySelector('.minint.single'));
   }
 </script>
 </body>

--- a/gh-pages/index.js
+++ b/gh-pages/index.js
@@ -22,5 +22,6 @@ function init_test_page() {
   $('.native time').attr('datetime', iso8601(new Date()));
   $('.jquery time').attr('datetime', iso8601(new Date()));
   $('.locales time').attr('datetime', iso8601(new Date()));
+  $('.minint time').attr('datetime', iso8601(new Date()));
 }
 

--- a/src/realtime.js
+++ b/src/realtime.js
@@ -11,7 +11,7 @@ const clear = tid => {
 };
 
 // 定时运行
-const run = (node, date, localeFunc, nowDate) => {
+const run = (node, date, localeFunc, nowDate, minInt) => {
   // 先清理掉之前的
   clear(getTimerId(node));
 
@@ -21,8 +21,8 @@ const run = (node, date, localeFunc, nowDate) => {
   node.innerHTML = formatDiff(diff, localeFunc);
 
   const tid = setTimeout(() => {
-    run(node, date, localeFunc, nowDate);
-  }, nextInterval(diff) * 1000, 0x7FFFFFFF);
+    run(node, date, localeFunc, nowDate, minInt);
+  }, Math.max(nextInterval(diff), minInt) * 1000, 0x7FFFFFFF);
 
   // there is no need to save node in object. Just save the key
   TimerPool[tid] = 0;
@@ -36,7 +36,7 @@ export const cancel = node => {
 };
 
 // 实时渲染一系列节点
-export const render = (nodes, locale, nowDate) => {
+export const render = (nodes, locale, nowDate, minInt = 1) => {
   // by .length
   if (nodes.length === undefined) nodes = [nodes];
 
@@ -46,7 +46,7 @@ export const render = (nodes, locale, nowDate) => {
 
     const date = getDateAttribute(node);
     const localeFunc = getLocale(locale);
-    run(node, date, localeFunc, nowDate);
+    run(node, date, localeFunc, nowDate, minInt);
   }
 
   return nodes;

--- a/timeago.d.ts
+++ b/timeago.d.ts
@@ -2,6 +2,6 @@
 type TDate = Date | string | number;
 
 export declare function format(date: TDate, locale?: string, relativeDate?: TDate): string;
-export declare function render<T>(nodes: Node | NodeList | JQuery, locale?: string, relativeDate?: TDate): void;
+export declare function render<T>(nodes: Node | NodeList | JQuery, locale?: string, relativeDate?: TDate, minInt?: number): void;
 export declare function cancel(node?: Node | JQuery): void;
 export declare function register(locale: string, localeFunc: Function): void;


### PR DESCRIPTION
This PR adds the minimal interval option to refresh intto `timeago.render`.

This option will help developers to avoid disturbing users especially in case of having multiple sub-minute elements. An example is available at https://cl.ly/2r39322u3e23 (adapted from [gitlab-org/gitlab-ce#47976](https://gitlab.com/gitlab-org/gitlab-ce/issues/47976)).

Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>