### PR TITLE
Use Node.js 11 for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,6 @@ node_js:
   - '8'
   - '9'
   - '10'
+  - '11'
 after_success:
   - npm run coveralls


### PR DESCRIPTION
Use Node.js 11 (current release) for testing.

Node.js 6 (maintenance LTS until 2019-04) as well as EOL releases (7 and 9) are not included.

Closes #172 