### PR TITLE
Use jQuery 3.3.1 hosted on jQuery CDN for the demo

### DIFF
--- a/gh-pages/demo.html
+++ b/gh-pages/demo.html
@@ -67,7 +67,7 @@
 	Copyright &copy; 2016 How to user it, see <a href="https://timeago.org/" target="_blank" rel="nofollow">timeago.js</a>.
 	Updated by <a href="http://Github.com/hustcc">Hustcc</a>
 </div>
-<script src="https://cdn.bootcss.com/jquery/1.9.1/jquery.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.3.1.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
 <script src="./timeago.min.js"></script>
 <script src="./timeago.locales.min.js"></script>
 <script src="./index.js" type="text/javascript"></script>


### PR DESCRIPTION
- Update jQuery from 1.9.1 to 3.3.1 to mitigate [their multiple vulnerabilities](https://snyk.io/vuln/npm:jquery).
- Use jQuery hosted on the official [jQuery CDN](https://code.jquery.com/) for the demo as bootcss CDN is not stable.