### PR TITLE
Replace `innerHTML` with safer `innerText`

### DIFF
--- a/src/realtime.js
+++ b/src/realtime.js
@@ -18,7 +18,7 @@ const run = (node, date, localeFunc, nowDate) => {
   // get diff seconds
   const diff = diffSec(date, nowDate);
   // render
-  node.innerHTML = formatDiff(diff, localeFunc);
+  node.innerText = formatDiff(diff, localeFunc);
 
   const tid = setTimeout(() => {
     run(node, date, localeFunc, nowDate);


### PR DESCRIPTION
I'd like to use this module in a web extension. Submitting code which makes use of `innerHTML` will get the extension rejected by Mozilla (see https://developer.mozilla.org/en-US/docs/Web/API/Element/innerHTML). This PR therefore replaces `innerHTML` with `innerText`.