### PR TITLE
Fix Rollup uglify config

### DIFF
--- a/rollup.config.all.js
+++ b/rollup.config.all.js
@@ -18,9 +18,6 @@ export default {
     babel({
       exclude: 'node_modules/**',
     }),
-    uglify({
-      output: { comments: false },
-      compress: { warnings: false }
-    }),
+    uglify(),
   ],
 };

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -19,9 +19,6 @@ export default {
     babel({
       exclude: 'node_modules/**',
     }),
-    uglify({
-      output: { comments: false },
-      compress: { warnings: false }
-    }),
+    uglify(),
   ],
 };


### PR DESCRIPTION
The code fails to build with the current configuration of the `rollup-plugin-uglify` plugin. This PR removes the config altogether since all options specified previously [are the defaults](https://github.com/mishoo/UglifyJS2/blob/master/README.md#minify-options).