### PR TITLE
docs: added CDN instructions 

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,13 @@ or import with `script` tag in html file and access global variable `timeago`.
 format('2016-06-12', 'en_US');
 ```
 
+## CDN 
+
+Alternatively to NPM, you can also use a CDN which will reflect the latest version as soon as it is published to npm.
+
+```html
+<script src="//unpkg.com/timeago.js"></script>
+```
 
 ## API
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "main": "lib/index.js",
   "module": "esm/index.js",
   "unpkg": "dist/timeago.min.js",
+  "browser": "dist/timeago.min.js",
   "files": [
     "lib",
     "esm",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "description": "timeago.js is a simple library (only 1kb) to used to format datetime with `*** time ago` statement. eg: '3 hours ago'. localization supported.",
   "main": "lib/index.js",
   "module": "esm/index.js",
+  "unpkg": "dist/timeago.min.js",
   "files": [
     "lib",
     "esm",


### PR DESCRIPTION
### Issue being fixed or implemented  

Right now, there is already a CDN link, using unpkg.com, specified in badges. 
In order to provide more clarity (it might not be that much clear), this P.R proposes a simple snippet of code that can be directly copied and pasted in any HTML page. 

### What was done  

- Chore: Instructed unpkg.com to redirect to the minified file (using package.json/unpkg field). 
- Docs : Added basic code snippet in a CDN section

### Notes 

Right now, in order to use the CDN on HTML files, one would need to use the link : `//unpkg.com/timeago.js@4.0.2/dist/timeago.min.js`, this changes (in package.json) allows to directly use `//unpkg.com/timeago.js` (as esm gets exported first).
