### PR TITLE
Fix german translation for "right now"

### DIFF
--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -1,6 +1,6 @@
 export default function(number: number, index: number): [string, string] {
   return [
-    ['gerade eben', 'vor einer Weile'],
+    ['gerade eben', 'gleich'],
     ['vor %s Sekunden', 'in %s Sekunden'],
     ['vor 1 Minute', 'in 1 Minute'],
     ['vor %s Minuten', 'in %s Minuten'],


### PR DESCRIPTION
Original value "Vor einer Weile" means "a little while ago" which is probably not what one wants for a timestamp less than a second in the future. Reasonable German alternatives are "gleich", "unmittelbar", or "sofort"

Source: native German speaker