### PR TITLE
Fix documentation of timeago.render.

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,7 +66,7 @@ import * as timeago from 'timeago.js';</pre>
         Now, let's attach it to your timestamps on DOM ready:
       </p>
       <pre>
-timeago().render(document.querySelectorAll('.need_to_be_rendered'));</pre>
+timeago.render(document.querySelectorAll('.need_to_be_rendered'));</pre>
       <p class="how">
         This will realtime render all <tt>selected</tt>(javascript DOM selector) elements with a class of <tt>need_to_be_rendered</tt>.
       </p>


### PR DESCRIPTION
timeago does not appear to be a function, and indeed calling `timeago()` by itself throws an error indicating it is not a function.