### PR TITLE
Handle empty node list

### DIFF
--- a/src/realtime.ts
+++ b/src/realtime.ts
@@ -57,7 +57,8 @@ export function cancel(node?: HTMLElement): void {
 export function render(nodes: HTMLElement | HTMLElement[] | NodeList, locale?: string, opts?: Opts) {
   // by .length
   // @ts-ignore
-  const nodeList: HTMLElement[] = nodes.length ? nodes : [nodes];
+  // supports empty list of nodes
+  const nodeList: HTMLElement[] = NodeList.prototype.isPrototypeOf(nodes) ? nodes : [nodes];
 
   nodeList.forEach((node: HTMLElement) => {
     run(node, getDateAttribute(node), getLocale(locale), opts || {});


### PR DESCRIPTION
Implementation of the fix suggested in issue #230 : 

'Uncaught TypeError: node.getAttribute is not a function when passed an empty node list'

See https://github.com/hustcc/timeago.js/issues/230