### PR TITLE
Fix sourceMap support on package

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "files": [
     "lib",
     "esm",
+    "src",
     "dist"
   ],
   "scripts": {


### PR DESCRIPTION
Fixes https://github.com/hustcc/timeago.js/issues/240

This is something I have found when publishing my packages to NPM, the src directory is published to NPM which the .map files refer to. There might be some alternative way to embed sourceMap src or something, but this solution has worked for me! Thanks for this package