### PR TITLE
fix: switch toString w/ toLocaleString to be able to format numbers in formatDiff

### DIFF
--- a/src/format.ts
+++ b/src/format.ts
@@ -1,6 +1,6 @@
-import { formatDiff, diffSec } from './utils/date';
-import { getLocale } from './register';
 import { Opts, TDate } from './interface';
+import { getLocale } from './register';
+import { diffSec, formatDiff } from './utils/date';
 
 /**
  * format a TDate into string
@@ -12,5 +12,5 @@ export const format = (date: TDate, locale?: string, opts?: Opts): string => {
   // diff seconds
   const sec = diffSec(date, opts && opts.relativeDate);
   // format it with locale
-  return formatDiff(sec, getLocale(locale));
+  return formatDiff(sec, getLocale(locale), opts?.numberLocale);
 };

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -14,4 +14,6 @@ export type Opts = {
   readonly relativeDate?: TDate;
   /** the realtime */
   readonly minInterval?: number;
+  /** the locale used to format the number part of the relative time */
+  readonly numberLocale?: string;
 };

--- a/src/realtime.ts
+++ b/src/realtime.ts
@@ -1,7 +1,7 @@
-import { setTimerId, getTimerId, getDateAttribute } from './utils/dom';
-import { formatDiff, diffSec, nextInterval } from './utils/date';
-import { getLocale } from './register';
 import { LocaleFunc, Opts, TimerPool } from './interface';
+import { getLocale } from './register';
+import { diffSec, formatDiff, nextInterval } from './utils/date';
+import { getDateAttribute, getTimerId, setTimerId } from './utils/dom';
 
 // all realtime timer
 const TIMER_POOL: TimerPool = {};
@@ -20,16 +20,19 @@ function run(node: HTMLElement, date: string, localeFunc: LocaleFunc, opts: Opts
   // clear the node's exist timer
   clear(getTimerId(node));
 
-  const { relativeDate, minInterval } = opts;
+  const { relativeDate, minInterval, numberLocale } = opts;
 
   // get diff seconds
   const diff = diffSec(date, relativeDate);
   // render
-  node.innerText = formatDiff(diff, localeFunc);
+  node.innerText = formatDiff(diff, localeFunc, numberLocale);
 
-  const tid = (setTimeout(() => {
-    run(node, date, localeFunc, opts);
-  }, Math.min(Math.max(nextInterval(diff), minInterval || 1) * 1000, 0x7fffffff)) as unknown) as number;
+  const tid = setTimeout(
+    () => {
+      run(node, date, localeFunc, opts);
+    },
+    Math.min(Math.max(nextInterval(diff), minInterval || 1) * 1000, 0x7fffffff),
+  ) as unknown as number;
 
   // there is no need to save node in object. Just save the key
   TIMER_POOL[tid] = 0;

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -41,7 +41,7 @@ export function toDate(input?: Date | string | number): Date {
  * @param localeFunc
  * @returns
  */
-export function formatDiff(diff: number, localeFunc: LocaleFunc): string {
+export function formatDiff(diff: number, localeFunc: LocaleFunc, numberLocale?: string): string {
   /**
    * if locale is not exist, use defaultLocale.
    * if defaultLocale is not exist, use build-in `en`.
@@ -90,7 +90,7 @@ export function formatDiff(diff: number, localeFunc: LocaleFunc): string {
 
   if (diff > (idx === 0 ? 9 : 1)) idx += 1;
 
-  return localeFunc(diff, idx, totalSec)[agoIn].replace('%s', diff.toString());
+  return localeFunc(diff, idx, totalSec)[agoIn].replace('%s', diff.toLocaleString(numberLocale));
 }
 
 /**


### PR DESCRIPTION
This PR fixes the issue of displaying numbers in english all the time regardless of the selected locale by adding `numberLocale` option

Issue was: `منذ 3 دقائق` showing english number in arabic

With this PR you can do this:

```
render(node, 'ar', { numberLocale: 'ar-u-nu-arab' })
```

and it takes the correct form: `منذ ٣ دقائق`