### PR TITLE
fix(nextInterval): use the absolute diff so future times re-render correctly

### DIFF
--- a/__tests__/utils/date.spec.ts
+++ b/__tests__/utils/date.spec.ts
@@ -39,6 +39,10 @@ describe('date', () => {
     expect(nextInterval(110)).toEqual(10);
     expect(nextInterval(2 * 3600 + 100)).toEqual(3500);
     expect(nextInterval(3600 * 24 + 3600)).toEqual(23 * 3600);
+    // future times (negative diff) must use the same interval as past times
+    expect(nextInterval(-110)).toEqual(10);
+    expect(nextInterval(-(2 * 3600 + 100))).toEqual(3500);
+    expect(nextInterval(-(3600 * 24 + 3600))).toEqual(23 * 3600);
   });
 });
 

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -112,9 +112,12 @@ export function diffSec(date: TDate, relativeDate?: TDate): number {
  * make the interval with high performance.
  **/
 export function nextInterval(diff: number): number {
+  // Use the absolute diff so future times (negative diff) walk the unit
+  // buckets too; otherwise the loop is skipped and the result is always 1.
+  diff = Math.abs(diff);
   let rst = 1,
     i = 0,
-    d = Math.abs(diff);
+    d = diff;
   for (; diff >= SEC_ARRAY[i] && i < SEC_ARRAY.length; i++) {
     diff /= SEC_ARRAY[i];
     rst *= SEC_ARRAY[i];


### PR DESCRIPTION
## Problem

For a future time, `nextInterval` always returns `1`, so `realtime.render` re-runs its `setTimeout` every second for any future-dated node, instead of sleeping until the displayed unit actually changes.

```js
nextInterval(7300)   // 3500  ("2 hours ago"  -> wakes at the bucket boundary)
nextInterval(-7300)  // 1     ("in 2 hours"   -> wakes every second)  <- bug
nextInterval(-90000) // 1     (expected 82800)
```

The label is correct; only the wake-up interval is wrong, so future timers spin needlessly.

## Cause

`nextInterval` already computes `d = Math.abs(diff)` to support both past and future times, but the bucket loop iterates on the **signed** `diff`:

```ts
let rst = 1, i = 0, d = Math.abs(diff);
for (; diff >= SEC_ARRAY[i] && i < SEC_ARRAY.length; i++) { // diff < 0 for future times
  diff /= SEC_ARRAY[i];
  rst *= SEC_ARRAY[i];
}
```

When `diff < 0`, the condition `diff >= SEC_ARRAY[i]` is false immediately, the loop never runs, `rst` stays `1`, and the result is always `1`.

## Fix

Normalize `diff` to its absolute value before the loop, so future and past times share the same interval. The existing `Math.abs` showed the symmetric handling was already intended.

## Tests

Extended the `nextInterval` test with the future (negative-diff) cases mirroring the existing past cases. They fail on `master` (return `1`) and pass with the fix. Full suite green (159 tests).