### PR TITLE
fix(toDate): handle negative timezone offsets

### DIFF
--- a/__tests__/utils/date.spec.ts
+++ b/__tests__/utils/date.spec.ts
@@ -17,6 +17,24 @@ describe('date', () => {
     expect(toDate()).toBeInstanceOf(Date);
   });
 
+  test('toDate timezone offset', () => {
+    // positive offsets already worked
+    expect(toDate('2021-01-19T14:23:07+04:00').toISOString()).toEqual(
+      '2021-01-19T10:23:07.000Z',
+    );
+    // negative offsets used to produce an Invalid Date because the global
+    // `-` -> `/` replacement ate the offset's minus sign.
+    expect(toDate('2021-01-19T14:23:07-04:00').toISOString()).toEqual(
+      '2021-01-19T18:23:07.000Z',
+    );
+    expect(toDate('2021-01-19T14:23:07.418-04:00').toISOString()).toEqual(
+      '2021-01-19T18:23:07.000Z',
+    );
+    expect(toDate('2021-01-19T14:23:07-0530').toISOString()).toEqual(
+      '2021-01-19T19:53:07.000Z',
+    );
+  });
+
   test('formatDiff', () => {
     expect(formatDiff(100, getLocale('en_US'))).toEqual('1 minute ago');
     expect(formatDiff(-1000, getLocale('en_US'))).toEqual('in 16 minutes');

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -23,14 +23,21 @@ export function toDate(input?: Date | string | number): Date {
   if (input instanceof Date) return input;
   const s = String(input ?? '');
   if (!isNaN(input as number) || /^\d+$/.test(s)) return new Date(parseInt(s));
+  // Pull the trailing timezone offset off first so the global `-` -> `/`
+  // replacement below cannot eat the offset's minus sign (which previously
+  // turned `-04:00` into `/04:00` and produced an Invalid Date).
+  let tz = '';
   const normalized = s
     .trim()
+    .replace(/([+-]\d\d):?(\d\d)$/, (_m, h, m) => {
+      tz = ` ${h}${m}`; // -04:00 -> ' -0400'
+      return '';
+    })
     .replace(/\.\d+/, '') // remove milliseconds
     .replace(/-/g, '/')
     .replace(/(\d)T(\d)/, '$1 $2')
-    .replace(/Z/, ' UTC') // 2017-2-5T3:57:52Z -> 2017-2-5 3:57:52UTC
-    .replace(/([+-]\d\d):?(\d\d)/, ' $1$2'); // -04:00 -> -0400
-  return new Date(normalized);
+    .replace(/Z/, ' UTC'); // 2017-2-5T3:57:52Z -> 2017-2-5 3:57:52UTC
+  return new Date(normalized + tz);
 }
 
 /**


### PR DESCRIPTION
`toDate` returns an **Invalid Date** for any date string with a negative timezone offset:

```js
toDate('2021-01-19T14:23:07-04:00') // Invalid Date
toDate('2021-01-19T14:23:07+04:00') // OK
```

The global `-` → `/` replacement runs **before** the offset normalization, so it turns the offset's minus sign into a slash (`-04:00` → `/04:00`) and the final `new Date()` can't parse it. Positive offsets and `Z` are unaffected, so this silently breaks `format()` for any timestamp in the Americas.

Fix: pull the trailing offset out of the string before the hyphen replacement, then re-attach it. Date-portion hyphens are still handled exactly as before — non-offset inputs produce byte-identical output.

Added a regression test (`__tests__/utils/date.spec.ts`); it fails on `master` and passes with the fix. Full suite green (160 tests), `tsc --noEmit` clean.